### PR TITLE
fix: https 배포 후 swagger에서 cors 에러 발생

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,3 +44,6 @@ jwt:
 logging:
   level:
     org.springframework.security: DEBUG
+
+server:
+  forward-headers-strategy: framework


### PR DESCRIPTION
## 🛰️ Issue Number
#16 

## 🪐 작업 내용
스프링 프레임워크 레벨에서 forwarded 헤더를 해석해서 요청 정보를 “원래값”으로 바꿔줌

## 📚 Reference
