### PR TITLE
feat: 좌표 업로드 실패시 retry 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+    implementation "org.springframework.retry:spring-retry"
+    implementation "org.springframework:spring-aspects"
 }
 
 tasks.named('test') {

--- a/src/main/java/backend/capstone/domain/dayroute/exception/DayRouteErrorCode.java
+++ b/src/main/java/backend/capstone/domain/dayroute/exception/DayRouteErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum DayRouteErrorCode implements ErrorCode {
 
     CANNOT_ACCESS_DAY_ROUTE("해당 경로에 접근할 수 없습니다.", HttpStatus.UNAUTHORIZED),
-    DAY_ROUTE_CREATE_FAILED("일차 경로 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    DAY_ROUTE_CREATE_FAILED("일차 경로 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    GPS_POINT_UPLOAD_FAILURE("좌표 업로드에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/backend/capstone/domain/dayroute/service/DayRouteService.java
+++ b/src/main/java/backend/capstone/domain/dayroute/service/DayRouteService.java
@@ -16,7 +16,11 @@ import backend.capstone.global.exception.BusinessException;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,7 +32,13 @@ public class DayRouteService {
     private final GpsPointService gpsPointService;
     private final UserService userService;
 
-    //TODO: 업로드 실패 예외처리 필요
+    @Retryable(
+        retryFor = {
+            CannotAcquireLockException.class
+        },
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 100, multiplier = 2)
+    )
     @Transactional
     public GpsPointBatchUploadResponse uploadGpsPoint(Long userId,
         GpsPointBatchUploadRequest request) {
@@ -65,6 +75,13 @@ public class DayRouteService {
                             () -> new BusinessException(DayRouteErrorCode.DAY_ROUTE_CREATE_FAILED));
                 }
             });
+    }
+
+    @Recover
+    public GpsPointBatchUploadResponse recover(RuntimeException e, Long userId,
+        GpsPointBatchUploadRequest request) {
+        // 예: 도메인 예외로 변환
+        throw new BusinessException(DayRouteErrorCode.GPS_POINT_UPLOAD_FAILURE);
     }
 
 }

--- a/src/main/java/backend/capstone/global/config/RetryConfig.java
+++ b/src/main/java/backend/capstone/global/config/RetryConfig.java
@@ -1,0 +1,10 @@
+package backend.capstone.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#21 

## 🪐 작업 내용
좌표 일괄 업로드 API에 대한 부하 테스트(사용자 100명이 1초 안에 API를 동시 호출) 중 중복되지 않는 좌표들의 업로드 요청은 모두 잘 처리되었지만 중복 좌표에 한에서는 오류율이 무려 86%임을 확인
<img width="1037" height="151" alt="image" src="https://github.com/user-attachments/assets/58808242-c40c-4933-a068-203e0b62cd83" />

현재 gps_point에 (day_route_id, recorded_at) 유니크 인덱스가 걸려있던 상황
db는 insert 시점에 insert하는 row들의 유니크함을 유지하기 위해 유니크 인덱스 영역에 여러 락이 걸리던 상황
두 트랜잭션에서 서로가 필요한 락들을 점유하고 기다리는 순환 대기구조, 즉 **데드락**이 발생

좌표 업로드시 데드락 관련 예외 발생 시 해당 로직을 재시도하는 코드 추가
오류율이 86%에서 29%로 감소함
<img width="949" height="139" alt="image" src="https://github.com/user-attachments/assets/3a278189-6e7f-440e-b70d-0eba7426045f" />

## 📚 Reference
