### PR TITLE
refactor: dayRoute 도메인 facade 패턴 도입

### DIFF
--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteController.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteController.java
@@ -5,7 +5,7 @@ import backend.capstone.domain.dayroute.dto.DayRouteDetailResponse;
 import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadRequest;
 import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadResponse;
 import backend.capstone.domain.dayroute.dto.GpsPointsResponse;
-import backend.capstone.domain.dayroute.service.DayRouteService;
+import backend.capstone.domain.dayroute.facade.DayRouteFacade;
 import backend.capstone.domain.place.dto.PlaceAddRequest;
 import backend.capstone.domain.place.dto.PlaceAddResponse;
 import backend.capstone.domain.place.dto.PlaceUpdateRequest;
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/day-routes")
 public class DayRouteController implements DayRouteControllerSpec {
 
-    private final DayRouteService dayRouteService;
+    private final DayRouteFacade dayRouteFacade;
 
     @Override
     @PostMapping("/{date}/gps-points:batch")
@@ -36,7 +36,7 @@ public class DayRouteController implements DayRouteControllerSpec {
         @Valid @RequestBody GpsPointBatchUploadRequest request,
         @AuthenticationPrincipal UserPrincipal principal
     ) {
-        return dayRouteService.uploadGpsPoint(date, principal.userId(), request);
+        return dayRouteFacade.uploadGpsPoint(date, principal.userId(), request);
     }
 
     @Override
@@ -45,7 +45,7 @@ public class DayRouteController implements DayRouteControllerSpec {
         @PathVariable LocalDate date,
         @AuthenticationPrincipal UserPrincipal principal
     ) {
-        return dayRouteService.getGpsPoints(date, principal.userId());
+        return dayRouteFacade.getGpsPoints(date, principal.userId());
     }
 
     @Override
@@ -54,7 +54,7 @@ public class DayRouteController implements DayRouteControllerSpec {
         @PathVariable LocalDate date,
         @AuthenticationPrincipal UserPrincipal principal
     ) {
-        return dayRouteService.getDayRouteDetail(date, principal.userId());
+        return dayRouteFacade.getDayRouteDetail(date, principal.userId());
     }
 
     @Override
@@ -64,7 +64,7 @@ public class DayRouteController implements DayRouteControllerSpec {
         @AuthenticationPrincipal UserPrincipal principal,
         @RequestBody PlaceAddRequest request
     ) {
-        return dayRouteService.addPlaceToDayRoute(date, principal.userId(), request);
+        return dayRouteFacade.addPlaceToDayRoute(date, principal.userId(), request);
     }
 
     @PutMapping("/{date}/places/{placeId}")
@@ -74,7 +74,7 @@ public class DayRouteController implements DayRouteControllerSpec {
         @AuthenticationPrincipal UserPrincipal principal,
         @RequestBody PlaceUpdateRequest request
     ) {
-        return dayRouteService.updatePlace(date, principal.userId(), placeId, request);
+        return dayRouteFacade.updatePlace(date, principal.userId(), placeId, request);
     }
 
 }

--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
@@ -10,6 +10,7 @@ import backend.capstone.domain.place.dto.PlaceAddResponse;
 import backend.capstone.domain.place.dto.PlaceUpdateRequest;
 import backend.capstone.domain.place.dto.PlaceUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 
@@ -21,7 +22,7 @@ public interface DayRouteControllerSpec {
         description = "경로 변수로 넣어주는 date는 2026-03-08 같은 형식으로 넣어주세요<br>"
     )
     GpsPointBatchUploadResponse uploadGpsPoints(
-        LocalDate date,
+        @Parameter(example = "2026-01-01") LocalDate date,
         GpsPointBatchUploadRequest request,
         UserPrincipal principal
     );
@@ -33,7 +34,7 @@ public interface DayRouteControllerSpec {
             """
     )
     GpsPointsResponse getGpsPoints(
-        LocalDate date,
+        @Parameter(example = "2026-01-01") LocalDate date,
         UserPrincipal principal
     );
 
@@ -42,7 +43,7 @@ public interface DayRouteControllerSpec {
         description = "place의 orderIndex는 장소들의 순서이며 이 순서대로 오름차순 정렬해서 데이터가 반환됩니다."
     )
     DayRouteDetailResponse getDayRouteDetail(
-        LocalDate date,
+        @Parameter(example = "2026-01-01") LocalDate date,
         UserPrincipal principal
     );
 
@@ -50,7 +51,7 @@ public interface DayRouteControllerSpec {
         summary = "장소 등록 API"
     )
     PlaceAddResponse addPlaceToDayRoute(
-        LocalDate date,
+        @Parameter(example = "2026-01-01") LocalDate date,
         UserPrincipal principal,
         PlaceAddRequest request
     );
@@ -62,8 +63,8 @@ public interface DayRouteControllerSpec {
             """
     )
     PlaceUpdateResponse updatePlace(
-        LocalDate date,
-        Long placeId,
+        @Parameter(example = "2026-01-01") LocalDate date,
+        @Parameter(example = "1") Long placeId,
         UserPrincipal principal,
         PlaceUpdateRequest request
     );

--- a/src/main/java/backend/capstone/domain/dayroute/facade/DayRouteFacade.java
+++ b/src/main/java/backend/capstone/domain/dayroute/facade/DayRouteFacade.java
@@ -1,0 +1,97 @@
+package backend.capstone.domain.dayroute.facade;
+
+import backend.capstone.domain.dayroute.dto.DayRouteDetailResponse;
+import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadRequest;
+import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadResponse;
+import backend.capstone.domain.dayroute.dto.GpsPointsResponse;
+import backend.capstone.domain.dayroute.entity.DayRoute;
+import backend.capstone.domain.dayroute.exception.DayRouteErrorCode;
+import backend.capstone.domain.dayroute.mapper.DayRouteMapper;
+import backend.capstone.domain.dayroute.service.DayRouteService;
+import backend.capstone.domain.gpspoint.dto.GpsPointRecordedAtRange;
+import backend.capstone.domain.gpspoint.entity.GpsPoint;
+import backend.capstone.domain.gpspoint.service.GpsPointService;
+import backend.capstone.domain.place.dto.PlaceAddRequest;
+import backend.capstone.domain.place.dto.PlaceAddResponse;
+import backend.capstone.domain.place.dto.PlaceUpdateRequest;
+import backend.capstone.domain.place.dto.PlaceUpdateResponse;
+import backend.capstone.domain.place.entity.Place;
+import backend.capstone.domain.place.service.PlaceService;
+import backend.capstone.global.exception.BusinessException;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DayRouteFacade {
+
+    private final DayRouteService dayRouteService;
+    private final GpsPointService gpsPointService;
+    private final PlaceService placeService;
+
+    @Retryable(
+        retryFor = {
+            CannotAcquireLockException.class
+        },
+        maxAttempts = 3,
+        backoff = @Backoff(delay = 100, multiplier = 2)
+    )
+    @Transactional
+    public GpsPointBatchUploadResponse uploadGpsPoint(LocalDate date, Long userId,
+        GpsPointBatchUploadRequest request) {
+        DayRoute dayRoute = dayRouteService.getOrCreate(userId, date);
+        gpsPointService.batchInsert(dayRoute.getId(), request);
+
+        // 업로드된 좌표의 시간 범위로 DayRoute 시간 업데이트
+        GpsPointRecordedAtRange gpsPointRange = gpsPointService.getGpsPointRange(dayRoute);
+        dayRoute.updateTime(gpsPointRange.getStartTime(), gpsPointRange.getEndTime());
+
+        return new GpsPointBatchUploadResponse("좌표 업로드에 성공했습니다.");
+    }
+
+    @Transactional(readOnly = true)
+    public GpsPointsResponse getGpsPoints(LocalDate date, Long userId) {
+        DayRoute dayRoute = dayRouteService.getDayRouteByDateAndUserId(date, userId);
+        List<GpsPoint> gpsPoints = gpsPointService.getGpsPointsByDayRouteId(dayRoute);
+
+        return DayRouteMapper.toGpsPointsResponse(gpsPoints);
+    }
+
+    @Transactional(readOnly = true)
+    public DayRouteDetailResponse getDayRouteDetail(LocalDate date, Long userId) {
+        DayRoute dayRoute = dayRouteService.getDayRouteByDateAndUserId(date, userId);
+        List<Place> places = placeService.getPlacesByDayRoute(dayRoute);
+
+        return DayRouteMapper.toDayRouteDetailResponse(dayRoute, places);
+    }
+
+    @Transactional
+    public PlaceAddResponse addPlaceToDayRoute(LocalDate date, Long userId,
+        PlaceAddRequest request) {
+        DayRoute dayRoute = dayRouteService.getOrCreate(userId, date);
+
+        return placeService.addPlace(dayRoute, request);
+    }
+
+    @Transactional
+    public PlaceUpdateResponse updatePlace(LocalDate date, Long userId,
+        Long placeId, PlaceUpdateRequest request) {
+        DayRoute dayRoute = dayRouteService.getDayRouteByDateAndUserId(date, userId);
+
+        return placeService.updatePlace(dayRoute, placeId, request);
+    }
+
+    @Recover
+    public GpsPointBatchUploadResponse recover(RuntimeException e, Long userId,
+        GpsPointBatchUploadRequest request) {
+        // 예: 도메인 예외로 변환
+        throw new BusinessException(DayRouteErrorCode.GPS_POINT_UPLOAD_FAILURE);
+    }
+}

--- a/src/main/java/backend/capstone/domain/dayroute/service/DayRouteService.java
+++ b/src/main/java/backend/capstone/domain/dayroute/service/DayRouteService.java
@@ -1,32 +1,14 @@
 package backend.capstone.domain.dayroute.service;
 
-import backend.capstone.domain.dayroute.dto.DayRouteDetailResponse;
-import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadRequest;
-import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadResponse;
-import backend.capstone.domain.dayroute.dto.GpsPointsResponse;
 import backend.capstone.domain.dayroute.entity.DayRoute;
 import backend.capstone.domain.dayroute.exception.DayRouteErrorCode;
 import backend.capstone.domain.dayroute.mapper.DayRouteMapper;
 import backend.capstone.domain.dayroute.repository.DayRouteRepository;
-import backend.capstone.domain.gpspoint.dto.GpsPointRecordedAtRange;
-import backend.capstone.domain.gpspoint.entity.GpsPoint;
-import backend.capstone.domain.gpspoint.service.GpsPointService;
-import backend.capstone.domain.place.dto.PlaceAddRequest;
-import backend.capstone.domain.place.dto.PlaceAddResponse;
-import backend.capstone.domain.place.dto.PlaceUpdateRequest;
-import backend.capstone.domain.place.dto.PlaceUpdateResponse;
-import backend.capstone.domain.place.entity.Place;
-import backend.capstone.domain.place.service.PlaceService;
 import backend.capstone.domain.user.service.UserService;
 import backend.capstone.global.exception.BusinessException;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Recover;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,68 +17,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class DayRouteService {
 
     private final DayRouteRepository dayRouteRepository;
-    private final GpsPointService gpsPointService;
     private final UserService userService;
-    private final PlaceService placeService;
-
-    @Retryable(
-        retryFor = {
-            CannotAcquireLockException.class
-        },
-        maxAttempts = 3,
-        backoff = @Backoff(delay = 100, multiplier = 2)
-    )
-    @Transactional
-    public GpsPointBatchUploadResponse uploadGpsPoint(LocalDate date, Long userId,
-        GpsPointBatchUploadRequest request) {
-        DayRoute dayRoute = createDayRouteIfNotExists(userId, date);
-        gpsPointService.batchInsert(dayRoute.getId(), request);
-
-        // 업로드된 좌표의 시간 범위로 DayRoute 시간 업데이트
-        GpsPointRecordedAtRange gpsPointRange = gpsPointService.getGpsPointRange(dayRoute);
-        dayRoute.updateTime(gpsPointRange.getStartTime(), gpsPointRange.getEndTime());
-
-        return new GpsPointBatchUploadResponse("좌표 업로드에 성공했습니다.");
-    }
-
-    @Transactional(readOnly = true)
-    public GpsPointsResponse getGpsPoints(LocalDate date, Long userId) {
-        DayRoute dayRoute = getDayRouteByDateAndUserId(date, userId);
-        List<GpsPoint> gpsPoints = gpsPointService.getGpsPointsByDayRouteId(dayRoute);
-
-        return DayRouteMapper.toGpsPointsResponse(gpsPoints);
-    }
-
-    @Transactional(readOnly = true)
-    public DayRouteDetailResponse getDayRouteDetail(LocalDate date, Long userId) {
-        DayRoute dayRoute = getDayRouteByDateAndUserId(date, userId);
-        List<Place> places = placeService.getPlacesByDayRoute(dayRoute);
-
-        return DayRouteMapper.toDayRouteDetailResponse(dayRoute, places);
-    }
 
     @Transactional
-    public PlaceAddResponse addPlaceToDayRoute(LocalDate date, Long userId,
-        PlaceAddRequest request) {
-        DayRoute dayRoute = createDayRouteIfNotExists(userId, date);
-
-        return placeService.addPlace(dayRoute, request);
-    }
-
-    @Transactional
-    public PlaceUpdateResponse updatePlace(LocalDate date, Long userId,
-        Long placeId, PlaceUpdateRequest request) {
-        DayRoute dayRoute = getDayRouteByDateAndUserId(date, userId);
-
-        return placeService.updatePlace(dayRoute, placeId, request);
-    }
-
-    private DayRoute getDayRouteByDateAndUserId(LocalDate date, Long userId) {
+    public DayRoute getDayRouteByDateAndUserId(LocalDate date, Long userId) {
         return dayRouteRepository.findByUserIdAndDate(userId, date)
             .orElseThrow(() -> new BusinessException(DayRouteErrorCode.DAY_ROUTE_NOT_FOUND));
     }
 
-    private DayRoute createDayRouteIfNotExists(Long userId, LocalDate date) {
+    @Transactional
+    public DayRoute getOrCreate(Long userId, LocalDate date) {
         return dayRouteRepository.findByUserIdAndDate(userId, date)
             .orElseGet(() -> {
                 try {
@@ -111,10 +41,4 @@ public class DayRouteService {
             });
     }
 
-    @Recover
-    public GpsPointBatchUploadResponse recover(RuntimeException e, Long userId,
-        GpsPointBatchUploadRequest request) {
-        // 예: 도메인 예외로 변환
-        throw new BusinessException(DayRouteErrorCode.GPS_POINT_UPLOAD_FAILURE);
-    }
 }


### PR DESCRIPTION
## 🛰️ Issue Number


## 🪐 작업 내용
DayRouteService에서 GpsPointService, PlaceService 등 **여러 도메인의 서비스를 호출해서 조합**하는 기능을 담당했었음
DayRouteService가 하나의 단일 서비스가 아닌 다른 도메인 서비스를 호출하는 진입점으로 사용되고 있었음
따라서 기존 DayRouteService는 DayRouteFacade로 변경하여 facade 레이어를 추가함
```
controller
↓
facade
↓
service
↓
repository
```
repository에 접근하는 로직은 DayRouteService로 분리

## 📚 Reference
https://inpa.tistory.com/entry/GOF-%F0%9F%92%A0-%ED%8D%BC%EC%82%AC%EB%93%9CFacade-%ED%8C%A8%ED%84%B4-%EC%A0%9C%EB%8C%80%EB%A1%9C-%EB%B0%B0%EC%9B%8C%EB%B3%B4%EC%9E%90