### PR TITLE
Add place delete and reorder APIs for DayRoute

### DIFF
--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteController.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteController.java
@@ -7,12 +7,14 @@ import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadResponse;
 import backend.capstone.domain.dayroute.facade.DayRouteFacade;
 import backend.capstone.domain.place.dto.PlaceAddRequest;
 import backend.capstone.domain.place.dto.PlaceAddResponse;
+import backend.capstone.domain.place.dto.PlaceReorderRequest;
 import backend.capstone.domain.place.dto.PlaceUpdateRequest;
 import backend.capstone.domain.place.dto.PlaceUpdateResponse;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -66,6 +68,7 @@ public class DayRouteController implements DayRouteControllerSpec {
         return dayRouteFacade.addPlaceToDayRoute(date, principal.userId(), request);
     }
 
+    @Override
     @PutMapping("/{date}/places/{placeId}")
     public PlaceUpdateResponse updatePlace(
         @PathVariable LocalDate date,
@@ -74,6 +77,26 @@ public class DayRouteController implements DayRouteControllerSpec {
         @RequestBody PlaceUpdateRequest request
     ) {
         return dayRouteFacade.updatePlace(date, principal.userId(), placeId, request);
+    }
+
+    @Override
+    @DeleteMapping("/{date}/places/{placeId}")
+    public void deletePlace(
+        @PathVariable LocalDate date,
+        @PathVariable Long placeId,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        dayRouteFacade.deletePlace(date, principal.userId(), placeId);
+    }
+
+    @Override
+    @PutMapping("/{date}/places:reorder")
+    public void reorderPlaces(
+        @PathVariable LocalDate date,
+        @AuthenticationPrincipal UserPrincipal principal,
+        @RequestBody PlaceReorderRequest request
+    ) {
+        dayRouteFacade.reorderPlaces(date, principal.userId(), request);
     }
 
 }

--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
@@ -6,6 +6,7 @@ import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadRequest;
 import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadResponse;
 import backend.capstone.domain.place.dto.PlaceAddRequest;
 import backend.capstone.domain.place.dto.PlaceAddResponse;
+import backend.capstone.domain.place.dto.PlaceReorderRequest;
 import backend.capstone.domain.place.dto.PlaceUpdateRequest;
 import backend.capstone.domain.place.dto.PlaceUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -68,5 +69,23 @@ public interface DayRouteControllerSpec {
         PlaceUpdateRequest request
     );
 
+    @Operation(
+        summary = "장소 삭제 API"
+    )
+    void deletePlace(
+        @Parameter(example = "2026-01-01") LocalDate date,
+        @Parameter(example = "1") Long placeId,
+        UserPrincipal principal
+    );
+
+    @Operation(
+        summary = "장소 순서 변경 API",
+        description = "해당 일차의 placeId 전체를 새로운 순서대로 전달해야 합니다."
+    )
+    void reorderPlaces(
+        @Parameter(example = "2026-01-01") LocalDate date,
+        UserPrincipal principal,
+        PlaceReorderRequest request
+    );
 
 }

--- a/src/main/java/backend/capstone/domain/dayroute/facade/DayRouteFacade.java
+++ b/src/main/java/backend/capstone/domain/dayroute/facade/DayRouteFacade.java
@@ -14,6 +14,7 @@ import backend.capstone.domain.gpspoint.service.GpsPointService;
 import backend.capstone.domain.gpspoint.util.PolylineUtil;
 import backend.capstone.domain.place.dto.PlaceAddRequest;
 import backend.capstone.domain.place.dto.PlaceAddResponse;
+import backend.capstone.domain.place.dto.PlaceReorderRequest;
 import backend.capstone.domain.place.dto.PlaceUpdateRequest;
 import backend.capstone.domain.place.dto.PlaceUpdateResponse;
 import backend.capstone.domain.place.entity.Place;
@@ -93,6 +94,20 @@ public class DayRouteFacade {
         DayRoute dayRoute = dayRouteService.getDayRouteByDateAndUserId(date, userId);
 
         return placeService.updatePlace(dayRoute, placeId, request);
+    }
+
+    @Transactional
+    public void deletePlace(LocalDate date, Long userId, Long placeId) {
+        DayRoute dayRoute = dayRouteService.getDayRouteByDateAndUserId(date, userId);
+
+        placeService.deletePlace(dayRoute, placeId);
+    }
+
+    @Transactional
+    public void reorderPlaces(LocalDate date, Long userId, PlaceReorderRequest request) {
+        DayRoute dayRoute = dayRouteService.getDayRouteByDateAndUserId(date, userId);
+
+        placeService.reorderPlaces(dayRoute, request);
     }
 
     @Recover

--- a/src/main/java/backend/capstone/domain/place/dto/PlaceReorderRequest.java
+++ b/src/main/java/backend/capstone/domain/place/dto/PlaceReorderRequest.java
@@ -1,0 +1,9 @@
+package backend.capstone.domain.place.dto;
+
+import java.util.List;
+
+public record PlaceReorderRequest(
+    List<Long> placeIds
+) {
+
+}

--- a/src/main/java/backend/capstone/domain/place/exception/PlaceErrorCode.java
+++ b/src/main/java/backend/capstone/domain/place/exception/PlaceErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum PlaceErrorCode implements ErrorCode {
 
-    PLACE_NOT_FOUND("장소를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    PLACE_NOT_FOUND("장소를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_PLACE_REORDER_REQUEST("장소 순서 변경 요청이 올바르지 않습니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/backend/capstone/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/backend/capstone/domain/place/repository/PlaceRepository.java
@@ -5,6 +5,7 @@ import backend.capstone.domain.place.entity.Place;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,4 +21,33 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     List<Place> findByDayRouteOrderByOrderIndex(DayRoute dayRoute);
 
     Optional<Place> findByIdAndDayRoute(Long placeId, DayRoute dayRoute);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update Place p
+        set p.orderIndex = -p.orderIndex
+        where p.dayRoute = :dayRoute
+        """)
+    int negateOrderIndexesByDayRoute(@Param("dayRoute") DayRoute dayRoute);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update Place p
+        set p.orderIndex = :orderIndex
+        where p.id = :placeId
+          and p.dayRoute = :dayRoute
+        """)
+    int updateOrderIndexByIdAndDayRoute(@Param("placeId") Long placeId,
+        @Param("dayRoute") DayRoute dayRoute,
+        @Param("orderIndex") int orderIndex);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update Place p
+        set p.orderIndex = p.orderIndex - 1
+        where p.dayRoute = :dayRoute
+          and p.orderIndex > :orderIndex
+        """)
+    int decrementOrderIndexesGreaterThan(@Param("dayRoute") DayRoute dayRoute,
+        @Param("orderIndex") int orderIndex);
 }

--- a/src/main/java/backend/capstone/domain/place/service/PlaceService.java
+++ b/src/main/java/backend/capstone/domain/place/service/PlaceService.java
@@ -3,6 +3,7 @@ package backend.capstone.domain.place.service;
 import backend.capstone.domain.dayroute.entity.DayRoute;
 import backend.capstone.domain.place.dto.PlaceAddRequest;
 import backend.capstone.domain.place.dto.PlaceAddResponse;
+import backend.capstone.domain.place.dto.PlaceReorderRequest;
 import backend.capstone.domain.place.dto.PlaceUpdateRequest;
 import backend.capstone.domain.place.dto.PlaceUpdateResponse;
 import backend.capstone.domain.place.entity.Place;
@@ -10,7 +11,9 @@ import backend.capstone.domain.place.exception.PlaceErrorCode;
 import backend.capstone.domain.place.mapper.PlaceMapper;
 import backend.capstone.domain.place.repository.PlaceRepository;
 import backend.capstone.global.exception.BusinessException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +47,48 @@ public class PlaceService {
         place.update(request.roadAddress(), request.placeName());
 
         return PlaceMapper.toPlaceUpdateResponse(place);
+    }
+
+    @Transactional
+    public void deletePlace(DayRoute dayRoute, Long placeId) {
+        Place place = placeRepository.findByIdAndDayRoute(placeId, dayRoute)
+            .orElseThrow(() -> new BusinessException(PlaceErrorCode.PLACE_NOT_FOUND));
+
+        int deletedOrderIndex = place.getOrderIndex();
+        placeRepository.delete(place);
+        placeRepository.decrementOrderIndexesGreaterThan(dayRoute, deletedOrderIndex);
+    }
+
+    @Transactional
+    public void reorderPlaces(DayRoute dayRoute, PlaceReorderRequest request) {
+        List<Place> places = placeRepository.findByDayRouteOrderByOrderIndex(dayRoute);
+        List<Long> reorderedPlaceIds = request.placeIds();
+
+        validateReorderRequest(places, reorderedPlaceIds);
+
+        placeRepository.negateOrderIndexesByDayRoute(dayRoute);
+        for (int i = 0; i < reorderedPlaceIds.size(); i++) {
+            int updated = placeRepository.updateOrderIndexByIdAndDayRoute(
+                reorderedPlaceIds.get(i), dayRoute, i + 1);
+            if (updated == 0) {
+                throw new BusinessException(PlaceErrorCode.PLACE_NOT_FOUND);
+            }
+        }
+    }
+
+    private void validateReorderRequest(List<Place> places, List<Long> reorderedPlaceIds) {
+        if (reorderedPlaceIds == null || places.size() != reorderedPlaceIds.size()) {
+            throw new BusinessException(PlaceErrorCode.INVALID_PLACE_REORDER_REQUEST);
+        }
+
+        Set<Long> existingIds = new HashSet<>(places.stream()
+            .map(Place::getId)
+            .toList());
+
+        Set<Long> requestedIds = new HashSet<>(reorderedPlaceIds);
+        if (requestedIds.size() != reorderedPlaceIds.size() || !existingIds.equals(requestedIds)) {
+            throw new BusinessException(PlaceErrorCode.INVALID_PLACE_REORDER_REQUEST);
+        }
     }
 
 }


### PR DESCRIPTION
### Motivation
- Provide API endpoints to delete a place and to reorder places for a specific DayRoute while keeping the `Place` entity schema unchanged. 
- Ensure reindexing is performed safely to avoid unique-constraint conflicts and to compact order indexes after deletions.

### Description
- Added controller endpoints `DELETE /api/day-routes/{date}/places/{placeId}` and `PUT /api/day-routes/{date}/places:reorder` and corresponding spec entries to the DayRoute controller contract.
- Introduced facade methods `deletePlace` and `reorderPlaces` that resolve `DayRoute` by date/user and delegate to `PlaceService`.
- Added DTO `PlaceReorderRequest(List<Long> placeIds)` for reorder payloads and a new error code `INVALID_PLACE_REORDER_REQUEST` for invalid reorder requests.
- Implemented repository-level bulk update queries in `PlaceRepository` (`negateOrderIndexesByDayRoute`, `updateOrderIndexByIdAndDayRoute`, `decrementOrderIndexesGreaterThan`) to perform safe mass reindexing without changing the `Place` entity.
- Implemented `PlaceService.deletePlace` to remove a place and decrement subsequent `orderIndex` values, and `PlaceService.reorderPlaces` to validate the reorder list and reassign `orderIndex` values safely (negating existing indexes first to avoid unique constraint collisions).

### Testing
- Attempted to run automated tests with `./gradlew test` but the Gradle wrapper initially failed due to permission, and a subsequent run (`chmod +x gradlew && ./gradlew test`) could not download the Gradle distribution because of network/proxy restrictions resulting in an HTTP `403 Forbidden`, so tests were not executed in this environment.
- Static inspection and compilation-related edits were performed locally in the workspace to ensure code paths and method signatures are consistent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b79958d830832289a58ea061295fab)