### PR TITLE
Feat: 메모, 제목 작성, 즐찾 토글 기능 구현

### DIFF
--- a/src/main/java/backend/capstone/TestController.java
+++ b/src/main/java/backend/capstone/TestController.java
@@ -1,21 +1,28 @@
 package backend.capstone;
 
+import backend.capstone.auth.dto.UserPrincipal;
+import backend.capstone.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class TestController {
+
+    private final UserService userService;
 
     @Operation(summary = "테스트용 엔드포인트",
         description = """
-            서버가 정상적으로 작동하는지 확인하는 테스트용 엔드포인트입니다.
-            헤더에 엑세스 토큰을 넣어서 요청했을 때 200 상태코드와 함께 "test"문자열이 정상적으로 반환되는지 확인해보세요.
-            엑세스 토큰 만료 메시지를 받으면 재발급 API를 호출해주세요.
+            엑세스 토큰을 이용한 인증이 잘되고 있는지 확인하는 테스트용 엔드포인트입니다.<br>
+            헤더에 엑세스 토큰을 넣어서 요청했을 때 200 상태코드와 함께 "${nickname}님 환영합니다." 라는 문자열이 정상적으로 반환되는지 확인해보세요.<br>
+            엑세스 토큰 만료 메시지를 받으면 토큰 재발급 API를 호출해주세요.
             """)
     @GetMapping("/test")
-    public String test() {
-        return "test";
+    public String test(@AuthenticationPrincipal UserPrincipal principal) {
+        return userService.findById(principal.userId()).getNickname() + "님 환영합니다!";
     }
 
 }

--- a/src/main/java/backend/capstone/auth/controller/AuthControllerSpec.java
+++ b/src/main/java/backend/capstone/auth/controller/AuthControllerSpec.java
@@ -13,8 +13,8 @@ public interface AuthControllerSpec {
     @Operation(
         summary = "카카오 로그인",
         description = """
-            카카오 엑세스 토큰을 받아서 카카오 유저를 조회하고 db에 존재하는 유저면 로그인, 존재하지 않는 유저면 회원가입 후 로그인합니다.
-            응답받은 엑세스 토큰과 리프레시 토큰을 사용해주세요.
+            카카오 엑세스 토큰을 받아서 카카오 유저를 조회하고 db에 존재하는 유저면 로그인, 존재하지 않는 유저면 회원가입 후 로그인합니다.<br>
+            응답으로 받은 dayStartTime은 지나온길을 초기화하는 시작 시간이고, dayEndTime은 종료시간입니다.
             """
     )
     LoginResponse kakaoLogin(KakaoLoginRequest request);
@@ -30,7 +30,7 @@ public interface AuthControllerSpec {
             }
             ```
             X-Refresh-Token 헤더에 리프레시 토큰을 넣어주세요. 엑세스토큰은 넣지 않아도 됩니다.
-            이 API의 응답으로 받은 엑세스 토큰과 리프레시 토큰을 사용해주세요. (그전에 저장한 엑세스 토큰과 리프레시 토큰은 폐지) 
+            이 API의 응답으로 받은 엑세스 토큰과 리프레시 토큰을 사용해주세요. (그전에 저장한 엑세스 토큰과 리프레시 토큰은 폐지)
             """
     )
     TokenPair refresh(HttpServletRequest request, String refreshToken);

--- a/src/main/java/backend/capstone/auth/dto/LoginResponse.java
+++ b/src/main/java/backend/capstone/auth/dto/LoginResponse.java
@@ -1,9 +1,22 @@
 package backend.capstone.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalTime;
+
 public record LoginResponse(
     Long userId,
     String nickname,
     String profileImageUrl,
+
+    @Schema(type = "string", example = "00:00", description = "시작 시간 (HH:mm)")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    LocalTime dayStartTime,
+
+    @Schema(type = "string", example = "23:59", description = "종료 시간 (HH:mm)")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    LocalTime dayEndTime,
+
     String accessToken,
     String refreshToken
 ) {

--- a/src/main/java/backend/capstone/auth/service/AuthService.java
+++ b/src/main/java/backend/capstone/auth/service/AuthService.java
@@ -34,6 +34,7 @@ public class AuthService {
         refreshTokenService.save(user.getId(), refreshToken);
 
         return new LoginResponse(user.getId(), user.getNickname(), user.getProfileImageUrl(),
+            user.getDayStartTime(), user.getDayEndTime(),
             accessToken, refreshToken);
     }
 

--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteController.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteController.java
@@ -38,7 +38,7 @@ public class DayRouteController implements DayRouteControllerSpec {
     private final DayRouteFacade dayRouteFacade;
 
     @Override
-    @PostMapping("/{date}/gps-points")
+    @PostMapping("/{date}/gps-points:batch")
     public GpsPointBatchUploadResponse uploadGpsPoints(
         @PathVariable LocalDate date,
         @Valid @RequestBody GpsPointBatchUploadRequest request,

--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteController.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteController.java
@@ -2,6 +2,10 @@ package backend.capstone.domain.dayroute.controller;
 
 import backend.capstone.auth.dto.UserPrincipal;
 import backend.capstone.domain.dayroute.dto.DayRouteDetailResponse;
+import backend.capstone.domain.dayroute.dto.DayRouteMemoRequest;
+import backend.capstone.domain.dayroute.dto.DayRouteMemoResponse;
+import backend.capstone.domain.dayroute.dto.DayRouteTitleRequest;
+import backend.capstone.domain.dayroute.dto.DayRouteTitleResponse;
 import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadRequest;
 import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadResponse;
 import backend.capstone.domain.dayroute.facade.DayRouteFacade;
@@ -101,5 +105,25 @@ public class DayRouteController implements DayRouteControllerSpec {
         @Valid @RequestBody PlaceReorderRequest request
     ) {
         dayRouteFacade.reorderPlace(date, principal.userId(), request);
+    }
+
+    @Override
+    @PostMapping("/{date}/memo")
+    public DayRouteMemoResponse saveMemo(
+        @PathVariable LocalDate date,
+        @AuthenticationPrincipal UserPrincipal principal,
+        @RequestBody DayRouteMemoRequest request
+    ) {
+        return dayRouteFacade.saveMemo(date, principal.userId(), request);
+    }
+
+    @Override
+    @PostMapping("/{date}/title")
+    public DayRouteTitleResponse saveTitle(
+        @PathVariable LocalDate date,
+        @AuthenticationPrincipal UserPrincipal principal,
+        @RequestBody DayRouteTitleRequest request
+    ) {
+        return dayRouteFacade.saveTitle(date, principal.userId(), request);
     }
 }

--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteController.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteController.java
@@ -33,7 +33,7 @@ public class DayRouteController implements DayRouteControllerSpec {
     private final DayRouteFacade dayRouteFacade;
 
     @Override
-    @PostMapping("/{date}/gps-points:batch")
+    @PostMapping("/{date}/gps-points")
     public GpsPointBatchUploadResponse uploadGpsPoints(
         @PathVariable LocalDate date,
         @Valid @RequestBody GpsPointBatchUploadRequest request,

--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteController.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteController.java
@@ -1,6 +1,7 @@
 package backend.capstone.domain.dayroute.controller;
 
 import backend.capstone.auth.dto.UserPrincipal;
+import backend.capstone.domain.dayroute.dto.DayRouteBookmarkResponse;
 import backend.capstone.domain.dayroute.dto.DayRouteDetailResponse;
 import backend.capstone.domain.dayroute.dto.DayRouteMemoRequest;
 import backend.capstone.domain.dayroute.dto.DayRouteMemoResponse;
@@ -125,5 +126,14 @@ public class DayRouteController implements DayRouteControllerSpec {
         @RequestBody DayRouteTitleRequest request
     ) {
         return dayRouteFacade.saveTitle(date, principal.userId(), request);
+    }
+
+    @Override
+    @PostMapping("/{date}/bookmark")
+    public DayRouteBookmarkResponse toggleBookmark(
+        @PathVariable LocalDate date,
+        @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return dayRouteFacade.toggleBookmark(date, principal.userId());
     }
 }

--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
@@ -2,6 +2,10 @@ package backend.capstone.domain.dayroute.controller;
 
 import backend.capstone.auth.dto.UserPrincipal;
 import backend.capstone.domain.dayroute.dto.DayRouteDetailResponse;
+import backend.capstone.domain.dayroute.dto.DayRouteMemoRequest;
+import backend.capstone.domain.dayroute.dto.DayRouteMemoResponse;
+import backend.capstone.domain.dayroute.dto.DayRouteTitleRequest;
+import backend.capstone.domain.dayroute.dto.DayRouteTitleResponse;
 import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadRequest;
 import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadResponse;
 import backend.capstone.domain.place.dto.PlaceAddRequest;
@@ -18,12 +22,12 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 
-@Tag(name = "일차 경로 관련 API")
+@Tag(name = "day route API")
 public interface DayRouteControllerSpec {
 
     @Operation(
-        summary = "좌표 일괄 업로드 API",
-        description = "경로 변수로 넣어주는 date는 2026-03-08 같은 형식으로 넣어주세요<br>"
+        summary = "GPS point upload API",
+        description = "date path variable must be passed in yyyy-MM-dd format such as 2026-03-08."
     )
     GpsPointBatchUploadResponse uploadGpsPoints(
         @Parameter(example = "2026-01-01") LocalDate date,
@@ -31,20 +35,9 @@ public interface DayRouteControllerSpec {
         UserPrincipal principal
     );
 
-//    @Operation(
-//        summary = "좌표 목록 조회 API",
-//        description = """
-//            해당 일차의 좌표 목록을 조회합니다.
-//            """
-//    )
-//    GpsPointsResponse getGpsPoints(
-//        @Parameter(example = "2026-01-01") LocalDate date,
-//        UserPrincipal principal
-//    );
-
     @Operation(
-        summary = "해당 일차 조회 API",
-        description = "place의 orderIndex는 장소들의 순서이며 이 순서대로 오름차순 정렬해서 데이터가 반환됩니다."
+        summary = "day route detail API",
+        description = "Places are returned in ascending order by orderIndex."
     )
     DayRouteDetailResponse getDayRouteDetail(
         @Parameter(example = "2026-01-01") LocalDate date,
@@ -52,7 +45,25 @@ public interface DayRouteControllerSpec {
     );
 
     @Operation(
-        summary = "장소 등록 API"
+        summary = "memo save API"
+    )
+    DayRouteMemoResponse saveMemo(
+        @Parameter(example = "2026-01-01") LocalDate date,
+        UserPrincipal principal,
+        DayRouteMemoRequest request
+    );
+
+    @Operation(
+        summary = "title save API"
+    )
+    DayRouteTitleResponse saveTitle(
+        @Parameter(example = "2026-01-01") LocalDate date,
+        UserPrincipal principal,
+        DayRouteTitleRequest request
+    );
+
+    @Operation(
+        summary = "place add API"
     )
     PlaceAddResponse addPlaceToDayRoute(
         @Parameter(example = "2026-01-01") LocalDate date,
@@ -61,10 +72,8 @@ public interface DayRouteControllerSpec {
     );
 
     @Operation(
-        summary = "장소 수정 API",
-        description = """
-            수정되지 않은 정보도 값으로 넣어주세요. 해당 필드들은 DB에서 통째로 업데이트됩니다.
-            """
+        summary = "place update API",
+        description = "Send unchanged values as they are. The request fields fully overwrite the DB values."
     )
     PlaceUpdateResponse updatePlace(
         @Parameter(example = "2026-01-01") LocalDate date,
@@ -74,7 +83,7 @@ public interface DayRouteControllerSpec {
     );
 
     @Operation(
-        summary = "장소 삭제 API"
+        summary = "place delete API"
     )
     void deletePlace(
         @Parameter(example = "2026-01-01") LocalDate date,
@@ -83,10 +92,8 @@ public interface DayRouteControllerSpec {
     );
 
     @Operation(
-        summary = "장소 순서 재정렬 API",
-        description = """
-            재정렬된 placeId 배열 전체를 받아 해당 날짜의 장소 순서를 일괄 변경합니다.
-            """
+        summary = "place reorder API",
+        description = "Receives the full reordered placeId array and updates the place order for the date."
     )
     void reorderPlace(
         @Parameter(example = "2026-01-01") LocalDate date,

--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
@@ -22,12 +22,14 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 
-@Tag(name = "day route API")
+@Tag(name = "경로 API")
 public interface DayRouteControllerSpec {
 
     @Operation(
-        summary = "GPS point upload API",
-        description = "date path variable must be passed in yyyy-MM-dd format such as 2026-03-08."
+        summary = "좌표 업로드 API",
+        description = """
+            경로 변수로 들어오는 date는 2026-03-08 같은 형식으로 넣어주세요.
+            """
     )
     GpsPointBatchUploadResponse uploadGpsPoints(
         @Parameter(example = "2026-01-01") LocalDate date,
@@ -36,8 +38,8 @@ public interface DayRouteControllerSpec {
     );
 
     @Operation(
-        summary = "day route detail API",
-        description = "Places are returned in ascending order by orderIndex."
+        summary = "경로 조회 API",
+        description = "place는 orderIndex를 기준으로 오름차순 정렬되어 반환됩니다."
     )
     DayRouteDetailResponse getDayRouteDetail(
         @Parameter(example = "2026-01-01") LocalDate date,
@@ -45,7 +47,7 @@ public interface DayRouteControllerSpec {
     );
 
     @Operation(
-        summary = "memo save API"
+        summary = "메모 작성 API"
     )
     DayRouteMemoResponse saveMemo(
         @Parameter(example = "2026-01-01") LocalDate date,
@@ -54,7 +56,7 @@ public interface DayRouteControllerSpec {
     );
 
     @Operation(
-        summary = "title save API"
+        summary = "제목 작성 API"
     )
     DayRouteTitleResponse saveTitle(
         @Parameter(example = "2026-01-01") LocalDate date,
@@ -63,7 +65,7 @@ public interface DayRouteControllerSpec {
     );
 
     @Operation(
-        summary = "place add API"
+        summary = "장소 등록 API"
     )
     PlaceAddResponse addPlaceToDayRoute(
         @Parameter(example = "2026-01-01") LocalDate date,
@@ -72,8 +74,10 @@ public interface DayRouteControllerSpec {
     );
 
     @Operation(
-        summary = "place update API",
-        description = "Send unchanged values as they are. The request fields fully overwrite the DB values."
+        summary = "장소 수정 API",
+        description = """
+            수정하지 않은 필드도 그대로 넣어주세요. 요청 필드 값으로 DB 값이 그대로 덮어써집니다.(put mapping임)
+            """
     )
     PlaceUpdateResponse updatePlace(
         @Parameter(example = "2026-01-01") LocalDate date,
@@ -83,7 +87,7 @@ public interface DayRouteControllerSpec {
     );
 
     @Operation(
-        summary = "place delete API"
+        summary = "장소 삭제 API"
     )
     void deletePlace(
         @Parameter(example = "2026-01-01") LocalDate date,
@@ -92,8 +96,10 @@ public interface DayRouteControllerSpec {
     );
 
     @Operation(
-        summary = "place reorder API",
-        description = "Receives the full reordered placeId array and updates the place order for the date."
+        summary = "장소 순서 변경 API",
+        description = """
+            정렬된 placeId 배열 전체를 받아 해당 날짜의 장소 순서를 일괄 변경합니다.
+            """
     )
     void reorderPlace(
         @Parameter(example = "2026-01-01") LocalDate date,

--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
@@ -23,15 +23,16 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 
-@Tag(name = "지나온길 API")
+@Tag(name = "나의 지나온길 API")
 public interface DayRouteControllerSpec {
 
     @Operation(
-        summary = "좌표 업로드 API",
+        summary = "좌표, 이동거리 업로드 API",
         description = """
             경로 변수로 들어오는 date는 2026-03-08 같은 형식으로 넣어주세요.<br>
-            좌표는 10초 간격으로 모아서 업로드해주세요. (최대한 실시간성을 유지하기 위함)<br>
-            만약 좌표가 들어오지 않았다면 업로드하지 않아도 됩니다.
+            최대한 실시간성을 유지하기 위해 주기적으로 좌표를 업로드해주세요.<br>
+            이동거리는 km 단위이며 해당 날짜 기준 가장 마지막으로 들어온 값이 최종 이동거리가 됩니다.<br>
+            만약 새롭게 업로드할 좌표가 들어오지 않았다면 api를 호출하지 않아도 됩니다.
             """
     )
     GpsPointBatchUploadResponse uploadGpsPoints(
@@ -43,7 +44,7 @@ public interface DayRouteControllerSpec {
     @Operation(
         summary = "나의 지나온길 조회 API",
         description = """
-            해당 날짜의 좌표, 수기 장소, 메모, 제목 등 지나온길의 모든 데이터들이 반환됩니다.<br> 
+            해당 날짜의 좌표, 수기 장소, 메모, 제목 등 지나온길의 모든 데이터들이 반환됩니다.<br>
             encodedPath는 해당 날짜의 지나온길 좌표들을 인코딩한 값입니다.<br>
             pathPointCount는 좌표 개수를 의미합니다. <br>
             place는 orderIndex를 기준으로 오름차순 정렬되어 반환됩니다.

--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
@@ -23,13 +23,15 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 
-@Tag(name = "경로 API")
+@Tag(name = "지나온길 API")
 public interface DayRouteControllerSpec {
 
     @Operation(
         summary = "좌표 업로드 API",
         description = """
-            경로 변수로 들어오는 date는 2026-03-08 같은 형식으로 넣어주세요.
+            경로 변수로 들어오는 date는 2026-03-08 같은 형식으로 넣어주세요.<br>
+            좌표는 10초 간격으로 모아서 업로드해주세요. (최대한 실시간성을 유지하기 위함)<br>
+            만약 좌표가 들어오지 않았다면 업로드하지 않아도 됩니다.
             """
     )
     GpsPointBatchUploadResponse uploadGpsPoints(
@@ -40,7 +42,12 @@ public interface DayRouteControllerSpec {
 
     @Operation(
         summary = "나의 지나온길 조회 API",
-        description = "place는 orderIndex를 기준으로 오름차순 정렬되어 반환됩니다."
+        description = """
+            해당 날짜의 좌표, 수기 장소, 메모, 제목 등 지나온길의 모든 데이터들이 반환됩니다.<br> 
+            encodedPath는 해당 날짜의 지나온길 좌표들을 인코딩한 값입니다.<br>
+            pathPointCount는 좌표 개수를 의미합니다. <br>
+            place는 orderIndex를 기준으로 오름차순 정렬되어 반환됩니다.
+            """
     )
     DayRouteDetailResponse getDayRouteDetail(
         @Parameter(example = "2026-01-01") LocalDate date,

--- a/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
+++ b/src/main/java/backend/capstone/domain/dayroute/controller/DayRouteControllerSpec.java
@@ -1,6 +1,7 @@
 package backend.capstone.domain.dayroute.controller;
 
 import backend.capstone.auth.dto.UserPrincipal;
+import backend.capstone.domain.dayroute.dto.DayRouteBookmarkResponse;
 import backend.capstone.domain.dayroute.dto.DayRouteDetailResponse;
 import backend.capstone.domain.dayroute.dto.DayRouteMemoRequest;
 import backend.capstone.domain.dayroute.dto.DayRouteMemoResponse;
@@ -38,7 +39,7 @@ public interface DayRouteControllerSpec {
     );
 
     @Operation(
-        summary = "경로 조회 API",
+        summary = "나의 지나온길 조회 API",
         description = "place는 orderIndex를 기준으로 오름차순 정렬되어 반환됩니다."
     )
     DayRouteDetailResponse getDayRouteDetail(
@@ -62,6 +63,14 @@ public interface DayRouteControllerSpec {
         @Parameter(example = "2026-01-01") LocalDate date,
         UserPrincipal principal,
         DayRouteTitleRequest request
+    );
+
+    @Operation(
+        summary = "즐겨찾기 토글 API"
+    )
+    DayRouteBookmarkResponse toggleBookmark(
+        @Parameter(example = "2026-01-01") LocalDate date,
+        UserPrincipal principal
     );
 
     @Operation(
@@ -117,5 +126,4 @@ public interface DayRouteControllerSpec {
             )
         ) PlaceReorderRequest request
     );
-
 }

--- a/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteBookmarkResponse.java
+++ b/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteBookmarkResponse.java
@@ -1,0 +1,6 @@
+package backend.capstone.domain.dayroute.dto;
+
+public record DayRouteBookmarkResponse(
+    boolean isBookmarked
+) {
+}

--- a/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteDetailResponse.java
+++ b/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteDetailResponse.java
@@ -21,6 +21,8 @@ public record DayRouteDetailResponse(
         Long placeId,
         String placeName,
         String roadAddress,
+        double latitude,
+        double longitude,
         int orderIndex
     ) {
 

--- a/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteMemoRequest.java
+++ b/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteMemoRequest.java
@@ -1,0 +1,7 @@
+package backend.capstone.domain.dayroute.dto;
+
+public record DayRouteMemoRequest(
+    String memo
+) {
+
+}

--- a/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteMemoResponse.java
+++ b/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteMemoResponse.java
@@ -1,0 +1,7 @@
+package backend.capstone.domain.dayroute.dto;
+
+public record DayRouteMemoResponse(
+    String memo
+) {
+
+}

--- a/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteTitleRequest.java
+++ b/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteTitleRequest.java
@@ -1,0 +1,7 @@
+package backend.capstone.domain.dayroute.dto;
+
+public record DayRouteTitleRequest(
+    String title
+) {
+
+}

--- a/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteTitleResponse.java
+++ b/src/main/java/backend/capstone/domain/dayroute/dto/DayRouteTitleResponse.java
@@ -1,0 +1,7 @@
+package backend.capstone.domain.dayroute.dto;
+
+public record DayRouteTitleResponse(
+    String title
+) {
+
+}

--- a/src/main/java/backend/capstone/domain/dayroute/dto/GpsPointBatchUploadRequest.java
+++ b/src/main/java/backend/capstone/domain/dayroute/dto/GpsPointBatchUploadRequest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public record GpsPointBatchUploadRequest(
 //    String deviceId,
+    double distance,
     List<GpsPointRequest> gpsPoints
 ) {
 

--- a/src/main/java/backend/capstone/domain/dayroute/entity/DayRoute.java
+++ b/src/main/java/backend/capstone/domain/dayroute/entity/DayRoute.java
@@ -96,4 +96,8 @@ public class DayRoute {
         isBookmarked = !isBookmarked;
         return isBookmarked;
     }
+
+    public void updateDistance(double distance) {
+        this.totalDistance = distance;
+    }
 }

--- a/src/main/java/backend/capstone/domain/dayroute/entity/DayRoute.java
+++ b/src/main/java/backend/capstone/domain/dayroute/entity/DayRoute.java
@@ -83,4 +83,12 @@ public class DayRoute {
         this.encodedPath = encodedPath;
         this.pathPointCount = pathPointCount;
     }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateMemo(String memo) {
+        this.memo = memo;
+    }
 }

--- a/src/main/java/backend/capstone/domain/dayroute/entity/DayRoute.java
+++ b/src/main/java/backend/capstone/domain/dayroute/entity/DayRoute.java
@@ -91,4 +91,9 @@ public class DayRoute {
     public void updateMemo(String memo) {
         this.memo = memo;
     }
+
+    public boolean toggleBookmarked() {
+        isBookmarked = !isBookmarked;
+        return isBookmarked;
+    }
 }

--- a/src/main/java/backend/capstone/domain/dayroute/facade/DayRouteFacade.java
+++ b/src/main/java/backend/capstone/domain/dayroute/facade/DayRouteFacade.java
@@ -1,7 +1,7 @@
 package backend.capstone.domain.dayroute.facade;
 
-import backend.capstone.domain.dayroute.dto.DayRouteDetailResponse;
 import backend.capstone.domain.dayroute.dto.DayRouteBookmarkResponse;
+import backend.capstone.domain.dayroute.dto.DayRouteDetailResponse;
 import backend.capstone.domain.dayroute.dto.DayRouteMemoRequest;
 import backend.capstone.domain.dayroute.dto.DayRouteMemoResponse;
 import backend.capstone.domain.dayroute.dto.DayRouteTitleRequest;
@@ -58,7 +58,11 @@ public class DayRouteFacade {
 
         // 업로드된 좌표의 시간 범위로 DayRoute 시간 업데이트
         GpsPointRecordedAtRange gpsPointRange = gpsPointService.getGpsPointRange(dayRoute);
-        dayRoute.updateTime(gpsPointRange.getStartTime(), gpsPointRange.getEndTime());
+        dayRouteService.updateTime(dayRoute, gpsPointRange.startTime(),
+            gpsPointRange.endTime());
+
+        // 이동거리 업데이트
+        dayRouteService.updateDistance(dayRoute, request.distance());
 
         return new GpsPointBatchUploadResponse("좌표 업로드에 성공했습니다.");
     }

--- a/src/main/java/backend/capstone/domain/dayroute/facade/DayRouteFacade.java
+++ b/src/main/java/backend/capstone/domain/dayroute/facade/DayRouteFacade.java
@@ -1,6 +1,10 @@
 package backend.capstone.domain.dayroute.facade;
 
 import backend.capstone.domain.dayroute.dto.DayRouteDetailResponse;
+import backend.capstone.domain.dayroute.dto.DayRouteMemoRequest;
+import backend.capstone.domain.dayroute.dto.DayRouteMemoResponse;
+import backend.capstone.domain.dayroute.dto.DayRouteTitleRequest;
+import backend.capstone.domain.dayroute.dto.DayRouteTitleResponse;
 import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadRequest;
 import backend.capstone.domain.dayroute.dto.GpsPointBatchUploadResponse;
 import backend.capstone.domain.dayroute.dto.GpsPointsResponse;
@@ -109,6 +113,23 @@ public class DayRouteFacade {
         DayRoute dayRoute = dayRouteService.getDayRouteByDateAndUserId(date, userId);
 
         placeService.reorderPlace(dayRoute, request);
+    }
+
+    @Transactional
+    public DayRouteMemoResponse saveMemo(LocalDate date, Long userId, DayRouteMemoRequest request) {
+        DayRoute dayRoute = dayRouteService.getOrCreate(userId, date);
+        dayRouteService.updateMemo(dayRoute, request.memo());
+
+        return new DayRouteMemoResponse(dayRoute.getMemo());
+    }
+
+    @Transactional
+    public DayRouteTitleResponse saveTitle(LocalDate date, Long userId,
+        DayRouteTitleRequest request) {
+        DayRoute dayRoute = dayRouteService.getOrCreate(userId, date);
+        dayRouteService.updateTitle(dayRoute, request.title());
+
+        return new DayRouteTitleResponse(dayRoute.getTitle());
     }
 
     @Recover

--- a/src/main/java/backend/capstone/domain/dayroute/facade/DayRouteFacade.java
+++ b/src/main/java/backend/capstone/domain/dayroute/facade/DayRouteFacade.java
@@ -1,6 +1,7 @@
 package backend.capstone.domain.dayroute.facade;
 
 import backend.capstone.domain.dayroute.dto.DayRouteDetailResponse;
+import backend.capstone.domain.dayroute.dto.DayRouteBookmarkResponse;
 import backend.capstone.domain.dayroute.dto.DayRouteMemoRequest;
 import backend.capstone.domain.dayroute.dto.DayRouteMemoResponse;
 import backend.capstone.domain.dayroute.dto.DayRouteTitleRequest;
@@ -130,6 +131,14 @@ public class DayRouteFacade {
         dayRouteService.updateTitle(dayRoute, request.title());
 
         return new DayRouteTitleResponse(dayRoute.getTitle());
+    }
+
+    @Transactional
+    public DayRouteBookmarkResponse toggleBookmark(LocalDate date, Long userId) {
+        DayRoute dayRoute = dayRouteService.getOrCreate(userId, date);
+        boolean isBookmarked = dayRouteService.toggleBookmark(dayRoute);
+
+        return new DayRouteBookmarkResponse(isBookmarked);
     }
 
     @Recover

--- a/src/main/java/backend/capstone/domain/dayroute/mapper/DayRouteMapper.java
+++ b/src/main/java/backend/capstone/domain/dayroute/mapper/DayRouteMapper.java
@@ -48,6 +48,8 @@ public class DayRouteMapper {
                     .placeId(p.getId())
                     .placeName(p.getName())
                     .roadAddress(p.getRoadAddress())
+                    .latitude(p.getLatitude())
+                    .longitude(p.getLongitude())
                     .orderIndex(p.getOrderIndex())
                     .build())
                 .toList())

--- a/src/main/java/backend/capstone/domain/dayroute/service/DayRouteService.java
+++ b/src/main/java/backend/capstone/domain/dayroute/service/DayRouteService.java
@@ -7,6 +7,7 @@ import backend.capstone.domain.dayroute.repository.DayRouteRepository;
 import backend.capstone.domain.user.service.UserService;
 import backend.capstone.global.exception.BusinessException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -56,4 +57,13 @@ public class DayRouteService {
         return dayRoute.toggleBookmarked();
     }
 
+    @Transactional
+    public void updateTime(DayRoute dayRoute, LocalDateTime startTime, LocalDateTime endTime) {
+        dayRoute.updateTime(startTime, endTime);
+    }
+
+    @Transactional
+    public void updateDistance(DayRoute dayRoute, double distance) {
+        dayRoute.updateDistance(distance);
+    }
 }

--- a/src/main/java/backend/capstone/domain/dayroute/service/DayRouteService.java
+++ b/src/main/java/backend/capstone/domain/dayroute/service/DayRouteService.java
@@ -41,4 +41,14 @@ public class DayRouteService {
             });
     }
 
+    @Transactional
+    public void updateTitle(DayRoute dayRoute, String title) {
+        dayRoute.updateTitle(title);
+    }
+
+    @Transactional
+    public void updateMemo(DayRoute dayRoute, String memo) {
+        dayRoute.updateMemo(memo);
+    }
+
 }

--- a/src/main/java/backend/capstone/domain/dayroute/service/DayRouteService.java
+++ b/src/main/java/backend/capstone/domain/dayroute/service/DayRouteService.java
@@ -51,4 +51,9 @@ public class DayRouteService {
         dayRoute.updateMemo(memo);
     }
 
+    @Transactional
+    public boolean toggleBookmark(DayRoute dayRoute) {
+        return dayRoute.toggleBookmarked();
+    }
+
 }

--- a/src/main/java/backend/capstone/domain/gpspoint/dto/GpsPointRecordedAtRange.java
+++ b/src/main/java/backend/capstone/domain/gpspoint/dto/GpsPointRecordedAtRange.java
@@ -1,13 +1,10 @@
 package backend.capstone.domain.gpspoint.dto;
 
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-public class GpsPointRecordedAtRange {
+public record GpsPointRecordedAtRange(
+    LocalDateTime startTime,
+    LocalDateTime endTime
+) {
 
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
 }

--- a/src/main/java/backend/capstone/domain/place/dto/PlaceAddRequest.java
+++ b/src/main/java/backend/capstone/domain/place/dto/PlaceAddRequest.java
@@ -2,7 +2,9 @@ package backend.capstone.domain.place.dto;
 
 public record PlaceAddRequest(
     String roadAddress,
-    String placeName
+    String placeName,
+    double latitude,
+    double longitude
 ) {
 
 }

--- a/src/main/java/backend/capstone/domain/place/dto/PlaceAddResponse.java
+++ b/src/main/java/backend/capstone/domain/place/dto/PlaceAddResponse.java
@@ -7,6 +7,8 @@ public record PlaceAddResponse(
     Long placeId,
     String placeName,
     String roadAddress,
+    double latitude,
+    double longitude,
     int orderIndex
 ) {
 

--- a/src/main/java/backend/capstone/domain/place/dto/PlaceUpdateRequest.java
+++ b/src/main/java/backend/capstone/domain/place/dto/PlaceUpdateRequest.java
@@ -2,7 +2,9 @@ package backend.capstone.domain.place.dto;
 
 public record PlaceUpdateRequest(
     String roadAddress,
-    String placeName
+    String placeName,
+    double latitude,
+    double longitude
 ) {
 
 }

--- a/src/main/java/backend/capstone/domain/place/dto/PlaceUpdateResponse.java
+++ b/src/main/java/backend/capstone/domain/place/dto/PlaceUpdateResponse.java
@@ -5,7 +5,9 @@ import lombok.Builder;
 @Builder
 public record PlaceUpdateResponse(
     String roadAddress,
-    String placeName
+    String placeName,
+    double latitude,
+    double longitude
 ) {
 
 }

--- a/src/main/java/backend/capstone/domain/place/entity/Place.java
+++ b/src/main/java/backend/capstone/domain/place/entity/Place.java
@@ -1,6 +1,7 @@
 package backend.capstone.domain.place.entity;
 
 import backend.capstone.domain.dayroute.entity.DayRoute;
+import backend.capstone.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -25,7 +26,7 @@ import lombok.NoArgsConstructor;
             "order_index"})
     }
 )
-public class Place {
+public class Place extends BaseTimeEntity {
 
     @Id
     @Column(name = "place_id")

--- a/src/main/java/backend/capstone/domain/place/entity/Place.java
+++ b/src/main/java/backend/capstone/domain/place/entity/Place.java
@@ -40,19 +40,28 @@ public class Place {
 
     private String name;
 
+    private double latitude;
+
+    private double longitude;
+
     private int orderIndex;
 
     @Builder
-    Place(DayRoute dayRoute, String roadAddress, String name, int orderIndex) {
+    Place(DayRoute dayRoute, String roadAddress, String name, double latitude, double longitude,
+        int orderIndex) {
         this.dayRoute = dayRoute;
         this.roadAddress = roadAddress;
         this.name = name;
+        this.latitude = latitude;
+        this.longitude = longitude;
         this.orderIndex = orderIndex;
     }
 
-    public void update(String roadAddress, String name) {
+    public void update(String roadAddress, String name, double latitude, double longitude) {
         this.roadAddress = roadAddress;
         this.name = name;
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 
     public void changeOrderIndex(int orderIndex) {

--- a/src/main/java/backend/capstone/domain/place/mapper/PlaceMapper.java
+++ b/src/main/java/backend/capstone/domain/place/mapper/PlaceMapper.java
@@ -15,6 +15,8 @@ public class PlaceMapper {
             .dayRoute(dayRoute)
             .roadAddress(request.roadAddress())
             .name(request.placeName())
+            .latitude(request.latitude())
+            .longitude(request.longitude())
             .orderIndex(orderIndex)
             .build();
     }
@@ -24,6 +26,8 @@ public class PlaceMapper {
             .placeId(place.getId())
             .placeName(place.getName())
             .roadAddress(place.getRoadAddress())
+            .latitude(place.getLatitude())
+            .longitude(place.getLongitude())
             .orderIndex(place.getOrderIndex())
             .build();
     }
@@ -32,6 +36,8 @@ public class PlaceMapper {
         return PlaceUpdateResponse.builder()
             .roadAddress(place.getRoadAddress())
             .placeName(place.getName())
+            .latitude(place.getLatitude())
+            .longitude(place.getLongitude())
             .build();
     }
 

--- a/src/main/java/backend/capstone/domain/place/service/PlaceService.java
+++ b/src/main/java/backend/capstone/domain/place/service/PlaceService.java
@@ -45,7 +45,8 @@ public class PlaceService {
         Place place = placeRepository.findByIdAndDayRoute(placeId, dayRoute)
             .orElseThrow(() -> new BusinessException(PlaceErrorCode.PLACE_NOT_FOUND));
 
-        place.update(request.roadAddress(), request.placeName());
+        place.update(request.roadAddress(), request.placeName(), request.latitude(),
+            request.longitude());
 
         return PlaceMapper.toPlaceUpdateResponse(place);
     }

--- a/src/main/java/backend/capstone/domain/user/entity/User.java
+++ b/src/main/java/backend/capstone/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package backend.capstone.domain.user.entity;
 
+import backend.capstone.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id
     @Column(name = "user_id")

--- a/src/main/java/backend/capstone/domain/user/entity/User.java
+++ b/src/main/java/backend/capstone/domain/user/entity/User.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -35,14 +36,21 @@ public class User extends BaseTimeEntity {
 
     private String profileImageUrl;
 
+    private LocalTime dayStartTime;
+
+    private LocalTime dayEndTime;
+
     @Builder
     public User(ProviderType provider, String providerId, String nickname, String profileImageUrl) {
         this.provider = provider;
         this.providerId = providerId;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+        this.dayStartTime = LocalTime.MIDNIGHT;
+        this.dayEndTime = LocalTime.of(23, 59);
     }
 
+    //TODO: 프로필 변경 기능에서 사용
     public void updateProfile(String nickname, String profileImageUrl) {
         if (!Objects.equals(this.nickname, nickname)) {
             this.nickname = nickname;

--- a/src/main/java/backend/capstone/global/config/JpaAuditingConfig.java
+++ b/src/main/java/backend/capstone/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package backend.capstone.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/backend/capstone/global/entity/BaseTimeEntity.java
+++ b/src/main/java/backend/capstone/global/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package backend.capstone.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
     show-sql: true
 
 jwt:


### PR DESCRIPTION
## 🛰️ Issue Number


## 🪐 작업 내용
- jpa auditing 추가
- Place 엔티티에 latitude, longitude 필드 추가
- 메모, 제목 작성 api
- 즐찾 토글 api
- User 엔티티에 dayStartTime, dayEndTime 필드 추가
- 기존 좌표 업로드 api에서 이동거리도 함께 업로드하도록 변경
- dayRoute의 데이터 변경 및 조회에 접근하는 부분은 다 dayRouteService를 거치도록 리팩토링

## 📚 Reference
